### PR TITLE
feat: Implement array parsing, enum skipping if invalid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,10 @@ jsonSchemaAvro._isComplex = (schema) => {
 	return schema.type === 'object'
 }
 
+jsonSchemaAvro._isArray = (schema) => {
+	return schema.type === 'array'
+}
+
 jsonSchemaAvro._hasEnum = (schema) => {
 	return Boolean(schema.enum)
 }
@@ -38,6 +42,9 @@ jsonSchemaAvro._convertProperties = (schema) => {
 	return Object.keys(schema).map((item) => {
 		if(jsonSchemaAvro._isComplex(schema[item])){
 			return jsonSchemaAvro._convertComplexProperty(item, schema[item])
+		}
+		else if (jsonSchemaAvro._isArray(schema[item])) {
+			return jsonSchemaAvro._convertArrayProperty(item, schema[item])
 		}
 		else if(jsonSchemaAvro._hasEnum(schema[item])){
 			return jsonSchemaAvro._convertEnumProperty(item, schema[item])
@@ -54,7 +61,24 @@ jsonSchemaAvro._convertComplexProperty = (name, contents) => {
 			type: 'record',
 			name: `${name}_record`,
 			fields: jsonSchemaAvro._convertProperties(contents.properties || {})
-		} 
+		}
+	}
+}
+
+jsonSchemaAvro._convertArrayProperty = (name, contents) => {
+	return {
+		name: name,
+		doc: contents.description || '',
+		type: {
+			type: 'array',
+			items: jsonSchemaAvro._isComplex(contents.items)
+				? {
+					type: 'record',
+					name: `${name}_record`,
+					fields: jsonSchemaAvro._convertProperties(contents.items.properties || {})
+				}
+				: jsonSchemaAvro._convertProperty(name, contents.items)
+		}
 	}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const typeMapping = {
 	'number': 'float'
 }
 
-const symbolRe = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const reSymbol = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 jsonSchemaAvro.convert = (jsonSchema) => {
 	if(!jsonSchema){
@@ -85,7 +85,7 @@ jsonSchemaAvro._convertArrayProperty = (name, contents) => {
 }
 
 jsonSchemaAvro._convertEnumProperty = (name, contents) => {
-	const valid = contents.enum.every((symbol) => symbolRe.test(symbol))
+	const valid = contents.enum.every((symbol) => reSymbol.test(symbol))
 	let prop = {
 		name: name,
 		doc: contents.description || '',

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ const typeMapping = {
 	'number': 'float'
 }
 
+const symbolRe = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 jsonSchemaAvro.convert = (jsonSchema) => {
 	if(!jsonSchema){
 		throw new Error('No schema given')
@@ -83,14 +85,15 @@ jsonSchemaAvro._convertArrayProperty = (name, contents) => {
 }
 
 jsonSchemaAvro._convertEnumProperty = (name, contents) => {
+	const valid = contents.enum.every((symbol) => symbolRe.test(symbol))
 	let prop = {
 		name: name,
 		doc: contents.description || '',
-		type: {
+		type: valid ? {
 			type: 'enum',
 			name: `${name}_enum`,
 			symbols: contents.enum
-		}
+		} : 'string'
 	}
 	if(contents.hasOwnProperty('default')){
 		prop.default = contents.default


### PR DESCRIPTION
- implement missing array parsing.
- AVRO symbols in enum only allow `/^[A-Za-z_][A-Za-z0-9_]*$/` - use type 'string' if values are not valid