### PR TITLE
feat: Supports $ref if json-schema-ref-parser is present returning Promise<AvroSchema>

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   ],
   "homepage": "https://github.com/thedumbterminal/jsonschema-avro#readme",
   "devDependencies": {
-    "mocha": "^3.4.2"
+    "mocha": "^5.2.0"
+  },
+  "peerDependencies": {
+    "json-schema-ref-parser": "6.x"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,13 @@
 const jsonSchemaAvro = module.exports = {}
 
+let $RefParser;
+try {
+	$RefParser = require('json-schema-ref-parser');
+}
+catch(e) { 
+	$RefParser = null;
+}
+
 // Json schema on the left, avro on the right
 const typeMapping = {
 	'string': 'string',
@@ -11,10 +19,23 @@ const typeMapping = {
 
 const reSymbol = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-jsonSchemaAvro.convert = (jsonSchema) => {
-	if(!jsonSchema){
+jsonSchemaAvro.convert = async (schema) => {
+	if(!schema){
 		throw new Error('No schema given')
 	}
+	const avroSchema = $RefParser ?
+		await $RefParser.dereference(schema)
+		  .then(function(jsonSchema) {
+		    return jsonSchemaAvro._mainRecord(jsonSchema)
+		  })
+		  .catch(function(err) {
+		  	throw err;
+		  }) :
+		await Promise.resolve(jsonSchemaAvro._mainRecord(schema));
+	return avroSchema
+}
+
+jsonSchemaAvro._mainRecord = (jsonSchema) => {
 	return {
 		namespace: jsonSchemaAvro._convertId(jsonSchema.id),
 		name: 'main',

--- a/test/index.js
+++ b/test/index.js
@@ -15,12 +15,13 @@ describe('index', () => {
 				const expected = require(`../${sampleDir}/${dir}/expected.json`)
 				let result
 
-				before(() => {
-					result = jsonSchemaAvro.convert(inJson)
+				before(async () => {
+					result = await jsonSchemaAvro.convert(inJson)
 				})
 
 				it('converts to avro', () => {
 					//console.log(JSON.stringify(result, null, 2))
+					//console.log(JSON.stringify(expected, null, 2))
 					assert.deepEqual(result, expected)
 				})
 			})


### PR DESCRIPTION
**Added support for handling $ref through peerDependency**
- optional (uses json-schema-ref-parser if available; otherwise $ref continues to be ignored)
- changed convert to return a Promise of Avro Schema i.e. made it async