### PR TITLE
Allow for nullable enums which have values which conform to allowed enum symbols

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,16 +132,20 @@ jsonSchemaAvro._convertArrayProperty = (name, contents, parentPath = []) => {
 
 jsonSchemaAvro._convertEnumProperty = (name, contents, parentPath = []) => {
   const path = parentPath.concat(name)
+  let type = 'string';
+  if (contents.enum.every((symbol) => reSymbol.test(symbol))) {
+    type = {
+      type: 'enum',
+      name: `${path.join('_')}_enum`,
+      symbols: contents.enum,
+    }
+  } else if (contents.enum.includes(null)) {
+    type = ['null', 'string']
+  }
   const prop = {
     name,
     doc: contents.description || '',
-    type: contents.enum.every((symbol) => reSymbol.test(symbol))
-      ? {
-          type: 'enum',
-          name: `${path.join('_')}_enum`,
-          symbols: contents.enum,
-        }
-      : 'string',
+    type,
   }
   if (contents.default !== undefined) {
     prop.default = contents.default

--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,7 @@ jsonSchemaAvro._convertEnumProperty = (name, contents, parentPath = [], isRequir
   const path = parentPath.concat(name)
   const hasNull = contents.enum.includes(null)
   const symbols = contents.enum.filter((symbol) => symbol !== null)
-  const types = hasNull ? ['null'] : [];
+  const types = hasNull ? ['null'] : []
   if (symbols.every((symbol) => reSymbol.test(symbol))) {
     types.push({
       type: 'enum',

--- a/src/index.js
+++ b/src/index.js
@@ -76,17 +76,18 @@ jsonSchemaAvro._isRequired = (list, item) => list.includes(item)
 
 jsonSchemaAvro._convertProperties = (schema = {}, required = [], path = []) => {
   return Object.keys(schema).map((item) => {
+    const isRequired = jsonSchemaAvro._isRequired(required, item)
     if (jsonSchemaAvro._isComplex(schema[item])) {
       return jsonSchemaAvro._convertComplexProperty(item, schema[item], path)
     } else if (jsonSchemaAvro._isArray(schema[item])) {
       return jsonSchemaAvro._convertArrayProperty(item, schema[item], path)
     } else if (jsonSchemaAvro._hasEnum(schema[item])) {
-      return jsonSchemaAvro._convertEnumProperty(item, schema[item], path)
+      return jsonSchemaAvro._convertEnumProperty(item, schema[item], path, isRequired)
     }
     return jsonSchemaAvro._convertProperty(
       item,
       schema[item],
-      jsonSchemaAvro._isRequired(required, item)
+      isRequired
     )
   })
 }
@@ -130,25 +131,29 @@ jsonSchemaAvro._convertArrayProperty = (name, contents, parentPath = []) => {
   }
 }
 
-jsonSchemaAvro._convertEnumProperty = (name, contents, parentPath = []) => {
+jsonSchemaAvro._convertEnumProperty = (name, contents, parentPath = [], isRequired = false) => {
   const path = parentPath.concat(name)
-  let type = 'string';
-  if (contents.enum.every((symbol) => reSymbol.test(symbol))) {
-    type = {
+  const hasNull = contents.enum.includes(null)
+  const symbols = contents.enum.filter((symbol) => symbol !== null)
+  const types = hasNull ? ['null'] : [];
+  if (symbols.every((symbol) => reSymbol.test(symbol))) {
+    types.push({
       type: 'enum',
       name: `${path.join('_')}_enum`,
-      symbols: contents.enum,
-    }
-  } else if (contents.enum.includes(null)) {
-    type = ['null', 'string']
+      symbols,
+    })
+  } else {
+    types.push('string')
   }
   const prop = {
     name,
     doc: contents.description || '',
-    type,
+    type: types.length > 1 ? types : types.shift(),
   }
   if (contents.default !== undefined) {
     prop.default = contents.default
+  } else if (hasNull && !isRequired) {
+    prop.default = null
   }
   return prop
 }

--- a/test/samples/enum/expected.json
+++ b/test/samples/enum/expected.json
@@ -14,8 +14,24 @@
       }
     },
     {
+      "doc": "the name",
+      "name": "name",
+      "type": ["null", {
+        "name": "name_enum",
+        "symbols": ["Alice", "Adam"],
+        "type": "enum"
+      }],
+      "default": null
+    },
+    {
       "doc": "the age",
       "name": "age",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      "doc": "the height",
+      "name": "height",
       "type": ["null", "string"]
     }
   ]

--- a/test/samples/enum/expected.json
+++ b/test/samples/enum/expected.json
@@ -12,6 +12,11 @@
         "symbols": ["Male", "Female"],
         "type": "enum"
       }
+    },
+    {
+      "doc": "the age",
+      "name": "age",
+      "type": ["null", "string"]
     }
   ]
 }

--- a/test/samples/enum/input.json
+++ b/test/samples/enum/input.json
@@ -8,11 +8,21 @@
       "type": "string",
       "enum": ["Male", "Female"]
     },
+    "name": {
+      "description": "the name",
+      "type": ["null", "string"],
+      "enum": [null, "Alice", "Adam"]
+    },
     "age": {
       "description": "the age",
       "type": ["null", "string"],
       "enum": [null, "18_or_under", "over_18"]
+    },
+    "height": {
+      "description": "the height",
+      "type": ["null", "string"],
+      "enum": [null, "6ft_or_under", "over_6ft"]
     }
   },
-  "required": ["gender"]
+  "required": ["gender", "height"]
 }

--- a/test/samples/enum/input.json
+++ b/test/samples/enum/input.json
@@ -7,6 +7,11 @@
       "description": "the gender",
       "type": "string",
       "enum": ["Male", "Female"]
+    },
+    "age": {
+      "description": "the age",
+      "type": ["null", "string"],
+      "enum": [null, "18_or_under", "over_18"]
     }
   },
   "required": ["gender"]


### PR DESCRIPTION
Currently the schema forces a required "string" if an enum value starts with a number, even if the enum allows null