### PR TITLE
Conversion improvements for arrays, enums and support for draft 6 json schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsonschema-avro",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsonschema-avro",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "MIT",
       "devDependencies": {
         "avsc": "^5.7.7",

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ jsonSchemaAvro._idToNameSpace = (id) => {
   const url = new URL(id, 'http://nonamespace.int/')
   let nameSpace = []
   if (url.host !== 'nonamespace.int') {
-    const reverseHost = url.host.split(/\./).reverse()
+    const reverseHost = url.host.replace(/\-/g, '_').split(/\./).reverse()
     nameSpace = nameSpace.concat(reverseHost)
   }
   if (url.pathname) {
@@ -66,8 +66,8 @@ jsonSchemaAvro._idToName = (id) => {
 jsonSchemaAvro._sanitizedSplitPath = (path) => {
   return path
     .replace(/^\//, '')
-    .replace('.', '_')
-    .replace('-', '_')
+    .replace(/\./g, '_')
+    .replace(/\-/g, '_')
     .split(/\//)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,10 +46,7 @@ jsonSchemaAvro._idToNameSpace = (id) => {
     nameSpace = nameSpace.concat(reverseHost)
   }
   if (url.pathname) {
-    const splitPath = url.pathname
-      .replace(/^\//, '')
-      .replace('.', '_')
-      .split(/\//)
+    const splitPath = jsonSchemaAvro._sanitizedSplitPath(url.pathname)
     nameSpace = nameSpace.concat(splitPath.slice(0, splitPath.length - 1))
   }
   return nameSpace.join('.')
@@ -63,7 +60,15 @@ jsonSchemaAvro._idToName = (id) => {
   if (!url.pathname) {
     return
   }
-  return url.pathname.replace(/^\//, '').replace('.', '_').split(/\//).pop()
+  return jsonSchemaAvro._sanitizedSplitPath(url.pathname).pop()
+}
+
+jsonSchemaAvro._sanitizedSplitPath = (path) => {
+  return path
+    .replace(/^\//, '')
+    .replace('.', '_')
+    .replace('-', '_')
+    .split(/\//)
 }
 
 jsonSchemaAvro._isComplex = (schema) => schema.type === 'object'

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ jsonSchemaAvro._idToNameSpace = (id) => {
   const url = new URL(id, 'http://nonamespace.int/')
   let nameSpace = []
   if (url.host !== 'nonamespace.int') {
-    const reverseHost = url.host.replace(/\-/g, '_').split(/\./).reverse()
+    const reverseHost = url.host.replace(/-/g, '_').split(/\./).reverse()
     nameSpace = nameSpace.concat(reverseHost)
   }
   if (url.pathname) {

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ jsonSchemaAvro._sanitizedSplitPath = (path) => {
   return path
     .replace(/^\//, '')
     .replace(/\./g, '_')
-    .replace(/\-/g, '_')
+    .replace(/-/g, '_')
     .split(/\//)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -145,25 +145,24 @@ jsonSchemaAvro._convertEnumProperty = (name, contents, parentPath = [], isRequir
   const path = parentPath.concat(name)
   const hasNull = contents.enum.includes(null)
   const symbols = contents.enum.filter((symbol) => symbol !== null)
-  const types = hasNull ? ['null'] : []
-  if (symbols.every((symbol) => reSymbol.test(symbol))) {
-    types.push({
-      type: 'enum',
-      name: `${path.join('_')}_enum`,
-      symbols,
-    })
-  } else {
-    types.push('string')
-  }
   const prop = {
     name,
     doc: contents.description || '',
-    type: types.length > 1 ? types : types.shift(),
+    type: symbols.every((symbol) => reSymbol.test(symbol))
+      ? {
+          type: 'enum',
+          name: `${path.join('_')}_enum`,
+          symbols,
+        }
+      : 'string',
   }
   if (contents.default !== undefined) {
     prop.default = contents.default
-  } else if (hasNull && !isRequired) {
-    prop.default = null
+  } else if (hasNull || !isRequired) {
+    if (!isRequired) {
+      prop.default = null
+    }
+    prop.type = ['null', prop.type]
   }
   return prop
 }

--- a/src/index.js
+++ b/src/index.js
@@ -23,12 +23,12 @@ jsonSchemaAvro.convert = (jsonSchema) => {
     )
   }
   const record = {
-    name: jsonSchemaAvro._idToName(jsonSchema.id) || 'main',
+    name: jsonSchemaAvro._idToName(jsonSchema.id || jsonSchema.$id) || 'main',
     type: 'record',
     doc: jsonSchema.description,
     fields,
   }
-  const nameSpace = jsonSchemaAvro._idToNameSpace(jsonSchema.id)
+  const nameSpace = jsonSchemaAvro._idToNameSpace(jsonSchema.id || jsonSchema.$id)
   if (nameSpace) {
     record.namespace = nameSpace
   }

--- a/src/index.js
+++ b/src/index.js
@@ -185,6 +185,7 @@ jsonSchemaAvro._convertProperty = (name, value, isRequired = false) => {
     if (!Array.isArray(prop.type)) {
       prop.type = [prop.type]
     }
+    prop.type = prop.type.filter((t) => t !== 'null')
     prop.type.unshift('null')
   }
   return prop
@@ -194,9 +195,7 @@ jsonSchemaAvro._mapType = (type) => {
   let types = []
   if (Array.isArray(type)) {
     types = types.concat(
-      type
-        .filter((t) => t !== 'null')
-        .map((t) => typeMapping[t])
+      type.map((t) => typeMapping[t])
     )
   } else {
     types.push(typeMapping[type])

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const typeMapping = {
   string: 'string',
   null: 'null',
   boolean: 'boolean',
-  integer: 'int',
+  integer: 'long',
   number: 'float',
 }
 

--- a/test/samples/array/expected.json
+++ b/test/samples/array/expected.json
@@ -22,6 +22,16 @@
         "type": "array"
       }],
       "default": null
+    },
+    {
+      "doc": "multiple types array",
+      "name": "multiple_types",
+      "type": ["null", {
+        "doc": "a number or string",
+        "items": ["float", "string"],
+        "type": "array"
+      }],
+      "default": null
     }
   ]
 }

--- a/test/samples/array/expected.json
+++ b/test/samples/array/expected.json
@@ -1,21 +1,27 @@
 {
+  "namespace": "com.yourdomain.schemas",
+  "name": "myschema_json",
+  "type": "record",
   "doc": "Array example",
   "fields": [
     {
       "doc": "example array",
       "name": "list",
       "type": {
-        "items": {
-          "doc": "a string",
-          "name": "list",
-          "type": ["null", "string"],
-          "default": null
-        },
+        "doc": "a string",
+        "items": "string",
         "type": "array"
       }
+    },
+    {
+      "doc": "optional array",
+      "name": "sequence",
+      "type": ["null", {
+        "doc": "a number",
+        "items": "float",
+        "type": "array"
+      }],
+      "default": null
     }
-  ],
-  "name": "myschema_json",
-  "namespace": "com.yourdomain.schemas",
-  "type": "record"
+  ]
 }

--- a/test/samples/array/input.json
+++ b/test/samples/array/input.json
@@ -18,6 +18,14 @@
         "description": "a number",
         "type": "number"
       }
+    },
+    "multiple_types": {
+      "description": "multiple types array",
+      "type": "array",
+      "items": {
+        "description": "a number or string",
+        "type": ["number", "string"]
+      }
     }
   },
   "required": ["list"]

--- a/test/samples/array/input.json
+++ b/test/samples/array/input.json
@@ -10,6 +10,14 @@
         "description": "a string",
         "type": "string"
       }
+    },
+    "sequence": {
+      "description": "optional array",
+      "type": "array",
+      "items": {
+        "description": "a number",
+        "type": "number"
+      }
     }
   },
   "required": ["list"]

--- a/test/samples/enum/expected.json
+++ b/test/samples/enum/expected.json
@@ -33,6 +33,12 @@
       "doc": "the height",
       "name": "height",
       "type": ["null", "string"]
+    },
+    {
+      "doc": "the weight",
+      "name": "weight",
+      "type": ["null", "string"],
+      "default": null
     }
   ]
 }

--- a/test/samples/enum/input.json
+++ b/test/samples/enum/input.json
@@ -22,6 +22,11 @@
       "description": "the height",
       "type": ["null", "string"],
       "enum": [null, "6ft_or_under", "over_6ft"]
+    },
+    "weight": {
+      "description": "the weight",
+      "type": "string",
+      "enum": ["60kg_or_under", "over_60kg"]
     }
   },
   "required": ["gender", "height"]

--- a/test/samples/id_draft_6/expected.json
+++ b/test/samples/id_draft_6/expected.json
@@ -1,6 +1,6 @@
 {
   "namespace": "com.yourdomain.schemas",
-  "name": "myschema_json",
+  "name": "my_schema_json",
   "type": "record",
   "doc": "Example description",
   "fields": []

--- a/test/samples/id_draft_6/expected.json
+++ b/test/samples/id_draft_6/expected.json
@@ -1,0 +1,7 @@
+{
+  "namespace": "com.yourdomain.schemas",
+  "name": "myschema_json",
+  "type": "record",
+  "doc": "Example description",
+  "fields": []
+}

--- a/test/samples/id_draft_6/expected.json
+++ b/test/samples/id_draft_6/expected.json
@@ -1,5 +1,5 @@
 {
-  "namespace": "com.yourdomain.schemas",
+  "namespace": "com.your_domain.the_schemas",
   "name": "my_schema_json",
   "type": "record",
   "doc": "Example description",

--- a/test/samples/id_draft_6/input.json
+++ b/test/samples/id_draft_6/input.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://yourdomain.com/schemas/my-schema.json",
+  "$id": "http://your-domain.com/the-schemas/my.schema.json",
   "description": "Example description",
   "type": "object"
 }

--- a/test/samples/id_draft_6/input.json
+++ b/test/samples/id_draft_6/input.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://yourdomain.com/schemas/myschema.json",
+  "$id": "http://yourdomain.com/schemas/my-schema.json",
   "description": "Example description",
   "type": "object"
 }

--- a/test/samples/id_draft_6/input.json
+++ b/test/samples/id_draft_6/input.json
@@ -1,0 +1,5 @@
+{
+  "$id": "http://yourdomain.com/schemas/myschema.json",
+  "description": "Example description",
+  "type": "object"
+}

--- a/test/samples/integer/expected.json
+++ b/test/samples/integer/expected.json
@@ -1,0 +1,20 @@
+{
+  "namespace": "com.yourdomain.schemas",
+  "name": "myschema_json",
+  "type": "record",
+  "doc": "Integer example",
+  "fields": [
+    {
+      "doc": "a small integer",
+      "name": "month",
+      "type": "long",
+      "default": 12
+    },
+    {
+      "doc": "a long integer",
+      "name": "timestamp",
+      "type": "long",
+      "default": 1505569975000
+    }
+  ]
+}

--- a/test/samples/integer/input.json
+++ b/test/samples/integer/input.json
@@ -1,0 +1,17 @@
+{
+  "id": "http://yourdomain.com/schemas/myschema.json",
+  "description": "Integer example",
+  "type": "object",
+  "properties": {
+    "month": {
+      "description": "a small integer",
+      "type": "integer",
+      "default": 12
+    },
+    "timestamp": {
+      "description": "a long integer",
+      "type": "integer",
+      "default": 1505569975000
+    }
+  }
+}

--- a/test/samples/multiple_types/expected.json
+++ b/test/samples/multiple_types/expected.json
@@ -7,7 +7,7 @@
     {
       "doc": "the age",
       "name": "age",
-      "type": ["null", "float", "int"],
+      "type": ["null", "float", "long"],
       "default": null
     }
   ]

--- a/test/samples/required/expected.json
+++ b/test/samples/required/expected.json
@@ -28,6 +28,11 @@
         "name": "dates_record",
         "type": "record"
       }
+    },
+    {
+      "doc": "when a json schema requires the property to exist, but it can be null",
+      "name": "required_null",
+      "type": ["null", "string"]
     }
   ]
 }

--- a/test/samples/required/input.json
+++ b/test/samples/required/input.json
@@ -18,7 +18,11 @@
         }
       },
       "required": ["birth", "death"]
+    },
+    "required_null": {
+      "description": "when a json schema requires the property to exist, but it can be null",
+      "type": ["null", "string"]
     }
   },
-  "required": ["first_name", "dates"]
+  "required": ["first_name", "dates", "required_null"]
 }

--- a/test/validate.js
+++ b/test/validate.js
@@ -19,11 +19,7 @@ describe('validate', () => {
       it('a valid schema', function () {
         if (process.env.ONLY && dir !== process.env.ONLY) {
           this.skip()
-        } else if (dir === 'array') {
-          // Is this avro valid?
-          this.skip()
         }
-
         assert.doesNotThrow(() => {
           avro.Type.forSchema(schema)
         })


### PR DESCRIPTION
- Namespaces for draft 6 schemas ([`$id` property instead of `id`](https://json-schema.org/draft-06/json-schema-release-notes.html#q-what-are-the-changes-between-draft-04-and-draft-06))
- Convert optional arrays, and arrays with multiple types
- Convert enums without null but which are optional