### PR TITLE
fix: map JSON schema number to Avro schema double

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const typeMapping = {
   null: 'null',
   boolean: 'boolean',
   integer: 'long',
-  number: 'float',
+  number: 'double',
 }
 
 const RE_SYMBOL = /^[A-Za-z_][A-Za-z0-9_]*$/

--- a/test/integration/samples/array/expected.json
+++ b/test/integration/samples/array/expected.json
@@ -30,7 +30,7 @@
         "null",
         {
           "doc": "a number",
-          "items": "float",
+          "items": "double",
           "type": "array"
         }
       ],

--- a/test/integration/samples/array/expected.json
+++ b/test/integration/samples/array/expected.json
@@ -43,7 +43,7 @@
         "null",
         {
           "doc": "a number or string",
-          "items": ["float", "string"],
+          "items": ["double", "string"],
           "type": "array"
         }
       ],

--- a/test/integration/samples/multiple_types/expected.json
+++ b/test/integration/samples/multiple_types/expected.json
@@ -7,7 +7,7 @@
     {
       "doc": "the age",
       "name": "age",
-      "type": ["null", "float", "long"],
+      "type": ["null", "double", "long"],
       "default": null
     }
   ]


### PR DESCRIPTION
**Javascript**
The JavaScript Number type is a double-precision 64-bit binary format IEEE 754 value

[ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_encoding)

**Avro**
- float: A single precision (32 bit) IEEE 754 floating-point number.
- double: A double precision (64-bit) IEEE 754 floating-point number.

[ref](https://docs.oracle.com/cd/E26161_02/html/GettingStartedGuide/avroschemas.html)