### PR TITLE
Fix/array items

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ jsonSchemaAvro.convert = (jsonSchema) => {
     name,
     ...jsonSchemaAvro._convertProperties(jsonSchema, [], name),
   }
-  if (jsonSchema.description) {
+  if (jsonSchema.description && record.type !== 'array') {
     record.doc = String(jsonSchema.description)
   }
   const nameSpace = idUtils.toNameSpace(jsonSchema)
@@ -48,6 +48,12 @@ jsonSchemaAvro._convertProperties = (jsonSchema, parentPathList, rootName) => {
       parentPathList,
       true
     )
+    if(type === Object(type) && type.type === 'array' && type.items !== undefined) {
+      return {
+        type: type.type,
+        items: type.items,
+      }
+    }
     return {
       ...rest,
       ...type,
@@ -178,9 +184,6 @@ jsonSchemaAvro._convertArrayProperty = (
   const { doc, ...rest } = items
   if (Object.keys(rest).length === 1 && rest.type !== undefined) {
     avroSchema.type.items = rest.type
-    if (doc) {
-      avroSchema.type.doc = String(doc)
-    }
   }
 
   if (itemName) {

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ jsonSchemaAvro._convertProperties = (jsonSchema, parentPathList, rootName) => {
           isRequired
         ))
       } else if (jsonSchemaAvro._isArray(propertySchema)) {
-        if(propertySchema.items !== undefined) {
+        if(propertySchema.items !== undefined && typeof propertySchema.items !== 'boolean') {
           convertedProperties.push(jsonSchemaAvro._convertArrayProperty(
             propertyName,
             propertySchema,

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,8 @@ jsonSchemaAvro.convert = (jsonSchema) => {
   return record
 }
 
-jsonSchemaAvro._isComplex = (schema) => schema === Object(schema) && schema.type === 'object'
+jsonSchemaAvro._isComplex = (schema) =>
+  schema === Object(schema) && schema.type === 'object'
 
 jsonSchemaAvro._isArray = (schema) => schema.type === 'array'
 
@@ -48,7 +49,11 @@ jsonSchemaAvro._convertProperties = (jsonSchema, parentPathList, rootName) => {
       parentPathList,
       true
     )
-    if(type === Object(type) && type.type === 'array' && type.items !== undefined) {
+    if (
+      type === Object(type) &&
+      type.type === 'array' &&
+      type.items !== undefined
+    ) {
       return {
         type: type.type,
         items: type.items,
@@ -72,45 +77,59 @@ jsonSchemaAvro._convertProperties = (jsonSchema, parentPathList, rootName) => {
 
   return {
     ...avroSchema,
-    fields: Object.keys(properties).reduce((convertedProperties, propertyName) => {
-      const isRequired =
-        Array.isArray(required) === true &&
-        required.includes(propertyName) === true
-      const propertySchema = properties[propertyName]
+    fields: Object.keys(properties).reduce(
+      (convertedProperties, propertyName) => {
+        const isRequired =
+          Array.isArray(required) === true &&
+          required.includes(propertyName) === true
+        const propertySchema = properties[propertyName]
 
-      if (jsonSchemaAvro._isComplex(propertySchema)) {
-        convertedProperties.push(jsonSchemaAvro._convertComplexProperty(
-          propertyName,
-          propertySchema,
-          parentPathList,
-          isRequired
-        ))
-      } else if (jsonSchemaAvro._isArray(propertySchema)) {
-        if(propertySchema.items !== undefined && typeof propertySchema.items !== 'boolean') {
-          convertedProperties.push(jsonSchemaAvro._convertArrayProperty(
-            propertyName,
-            propertySchema,
-            parentPathList,
-            isRequired
-          ))
+        if (jsonSchemaAvro._isComplex(propertySchema)) {
+          convertedProperties.push(
+            jsonSchemaAvro._convertComplexProperty(
+              propertyName,
+              propertySchema,
+              parentPathList,
+              isRequired
+            )
+          )
+        } else if (jsonSchemaAvro._isArray(propertySchema)) {
+          if (
+            propertySchema.items !== undefined &&
+            typeof propertySchema.items !== 'boolean'
+          ) {
+            convertedProperties.push(
+              jsonSchemaAvro._convertArrayProperty(
+                propertyName,
+                propertySchema,
+                parentPathList,
+                isRequired
+              )
+            )
+          }
+        } else if (jsonSchemaAvro._hasEnum(propertySchema)) {
+          convertedProperties.push(
+            jsonSchemaAvro._convertEnumProperty(
+              propertyName,
+              propertySchema,
+              parentPathList,
+              isRequired
+            )
+          )
+        } else {
+          convertedProperties.push(
+            jsonSchemaAvro._convertProperty(
+              propertyName,
+              propertySchema,
+              isRequired
+            )
+          )
         }
-      } else if (jsonSchemaAvro._hasEnum(propertySchema)) {
-        convertedProperties.push(jsonSchemaAvro._convertEnumProperty(
-          propertyName,
-          propertySchema,
-          parentPathList,
-          isRequired
-        ))
-      } else {
-        convertedProperties.push(jsonSchemaAvro._convertProperty(
-          propertyName,
-          propertySchema,
-          isRequired
-        ))
-      }
 
-      return convertedProperties;
-    }, []),
+        return convertedProperties
+      },
+      []
+    ),
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ jsonSchemaAvro._convertProperties = (jsonSchema, parentPathList, rootName) => {
   const { properties, items, required } = jsonSchema
 
   if (items === Object(items)) {
-    const { type, ...rest } = jsonSchemaAvro._convertArrayProperty(
+    const { type } = jsonSchemaAvro._convertArrayProperty(
       rootName || '',
       jsonSchema,
       parentPathList,

--- a/src/index.js
+++ b/src/index.js
@@ -49,19 +49,8 @@ jsonSchemaAvro._convertProperties = (jsonSchema, parentPathList, rootName) => {
       parentPathList,
       true
     )
-    if (
-      type === Object(type) &&
-      type.type === 'array' &&
-      type.items !== undefined
-    ) {
-      return {
-        type: type.type,
-        items: type.items,
-      }
-    }
     return {
-      ...rest,
-      ...type,
+      ...type
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ jsonSchemaAvro._convertProperties = (jsonSchema, parentPathList, rootName) => {
       true
     )
     return {
-      ...type
+      ...type,
     }
   }
 

--- a/test/integration/samples/array/expected.json
+++ b/test/integration/samples/array/expected.json
@@ -9,7 +9,6 @@
       "name": "list",
       "type": {
         "type": "array",
-        "doc": "a string",
         "items": "string"
       }
     }

--- a/test/integration/samples/array_array/expected.json
+++ b/test/integration/samples/array_array/expected.json
@@ -10,7 +10,6 @@
       "type": {
         "type": "array",
         "items": {
-          "doc": "an array",
           "type": "array",
           "items": "string"
         }

--- a/test/integration/samples/array_array_complex/expected.json
+++ b/test/integration/samples/array_array_complex/expected.json
@@ -10,7 +10,6 @@
       "type": {
         "type": "array",
         "items": {
-          "doc": "an array",
           "type": "array",
           "items": {
             "name": "list_array_complex__record",

--- a/test/integration/samples/array_array_union_complex/expected.json
+++ b/test/integration/samples/array_array_union_complex/expected.json
@@ -9,7 +9,6 @@
       "name": "list_array_union_complex",
       "type": {
         "type": "array",
-        "doc": "an array",
         "items": [
           "string",
           {

--- a/test/integration/samples/array_boolean_items/expected.json
+++ b/test/integration/samples/array_boolean_items/expected.json
@@ -1,0 +1,7 @@
+{
+  "namespace": "com.yourdomain.schemas",
+  "name": "myschema_json",
+  "type": "record",
+  "doc": "Array with boolean items schema",
+  "fields": []
+}

--- a/test/integration/samples/array_boolean_items/input.json
+++ b/test/integration/samples/array_boolean_items/input.json
@@ -1,0 +1,13 @@
+{
+  "id": "http://yourdomain.com/schemas/myschema.json",
+  "description": "Array with boolean items schema",
+  "type": "object",
+  "properties": {
+    "list": {
+      "description": "example array with boolean items schema",
+      "type": "array",
+      "items": false
+    }
+  },
+  "required": ["list"]
+}

--- a/test/integration/samples/array_default/expected.json
+++ b/test/integration/samples/array_default/expected.json
@@ -8,7 +8,6 @@
       "doc": "array with default",
       "name": "default",
       "type": {
-        "doc": "a string",
         "items": "string",
         "type": "array"
       },

--- a/test/integration/samples/array_multiple_types/expected.json
+++ b/test/integration/samples/array_multiple_types/expected.json
@@ -10,7 +10,6 @@
       "type": [
         "null",
         {
-          "doc": "a number or string",
           "items": ["double", "string"],
           "type": "array"
         }

--- a/test/integration/samples/array_no_items/expected.json
+++ b/test/integration/samples/array_no_items/expected.json
@@ -1,0 +1,7 @@
+{
+  "namespace": "com.yourdomain.schemas",
+  "name": "myschema_json",
+  "type": "record",
+  "doc": "Array without items schema example",
+  "fields": []
+}

--- a/test/integration/samples/array_no_items/input.json
+++ b/test/integration/samples/array_no_items/input.json
@@ -1,0 +1,12 @@
+{
+  "id": "http://yourdomain.com/schemas/myschema.json",
+  "description": "Array without items schema example",
+  "type": "object",
+  "properties": {
+    "list": {
+      "description": "example array without items schema",
+      "type": "array"
+    }
+  },
+  "required": ["list"]
+}

--- a/test/integration/samples/array_optional/expected.json
+++ b/test/integration/samples/array_optional/expected.json
@@ -10,7 +10,6 @@
       "type": [
         "null",
         {
-          "doc": "a number",
           "items": "double",
           "type": "array"
         }

--- a/test/integration/samples/array_required/expected.json
+++ b/test/integration/samples/array_required/expected.json
@@ -8,7 +8,6 @@
       "doc": "required array",
       "name": "required",
       "type": {
-        "doc": "a string",
         "items": "string",
         "type": "array"
       }

--- a/test/integration/samples/optional_array/expected.json
+++ b/test/integration/samples/optional_array/expected.json
@@ -11,7 +11,6 @@
         "null",
         {
           "type": "array",
-          "doc": "a string",
           "items": "string"
         }
       ],
@@ -67,7 +66,6 @@
         {
           "type": "array",
           "items": {
-            "doc": "an array",
             "type": "array",
             "items": "string"
           }
@@ -83,7 +81,6 @@
         {
           "type": "array",
           "items": {
-            "doc": "an array",
             "type": "array",
             "items": {
               "name": "list_array_complex__record",
@@ -133,7 +130,6 @@
         "null",
         {
           "type": "array",
-          "doc": "an array",
           "items": [
             "string",
             {

--- a/test/integration/samples/root_array/expected.json
+++ b/test/integration/samples/root_array/expected.json
@@ -1,6 +1,5 @@
 {
   "namespace": "com.yourdomain.schemas",
-  "doc": "Simple array example",
   "name": "myschema_json",
   "type": "array",
   "items": "string"


### PR DESCRIPTION
### 1. Omit doc
Fix: Removed assignment of unsupported doc property to array types.

**Rationale**:
From [Avro docs](https://docs.oracle.com/cd/E26161_02/html/GettingStartedGuide/avroschemas.html):

Defines an array field. It only supports the items attribute, which is required

Defined in avsc as:
```
interface ArrayType {
    type: "array";
    items: Schema;
}
```

### 2. Omit if items schema undefined or given as boolean
Fix: Omit undefined and boolean JSON items in Avro.

Rationale:
From JSON schema 6, array items in json-schema have type:
```
items?: JSONSchema6Definition | JSONSchema6Definition[] | undefined;
```
Items with type undefined or boolean (JSONSchema6Definition = JSONSchema6 | boolean) have no Avro equivalent.

Examples:
```
  {
    'id': 'http://yourdomain.com/schemas/myschema.json',
    'type': 'object',
    'properties': {
      'foo': {
        'type': 'array'
      },
    },
  };
```
```
  {
    'id': 'http://yourdomain.com/schemas/myschema.json',
    'type': 'object',
    'properties': {
      'foo': {
        'type': 'array',
        'items': false,
      },
    },
  };
```